### PR TITLE
Add missing include in /tools/quake3/common/threads.c

### DIFF
--- a/tools/quake3/common/threads.c
+++ b/tools/quake3/common/threads.c
@@ -24,6 +24,7 @@
 // pthreads extensions like pthread_mutexattr_settype
 #define _GNU_SOURCE
 #include <pthread.h>
+#include <stdint.h>
 #endif
 
 #include "cmdlib.h"


### PR DESCRIPTION
The build was failing on

```upgRadiant/tools/quake3/common/threads.c: In function ‘RunThreadsOn’:
upgRadiant/tools/quake3/common/threads.c:555:70: error: ‘uintptr_t’ undeclared (first use in this function)
  555 |    if ( pthread_create( &work_threads[i], NULL, (void*)func, (void*)(uintptr_t)i ) != 0 ) {
      |                                                                      ^~~~~~~~~
upgRadiant/tools/quake3/common/threads.c:555:70: note: each undeclared identifier is reported only once for each function it appears in
upgRadiant/tools/quake3/common/threads.c:555:80: error: expected ‘)’ before ‘i’
  555 |    if ( pthread_create( &work_threads[i], NULL, (void*)func, (void*)(uintptr_t)i ) != 0 ) {
      |                                                                                ^
      |                                                                                )
make[2]: *** [CMakeFiles/q3common.dir/build.make:173: CMakeFiles/q3common.dir/tools/quake3/common/threads.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:837: CMakeFiles/q3common.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
```

I've included `stdint.h` if WIN32 is undefined